### PR TITLE
Add endpoint for the probePath expected by draft pack

### DIFF
--- a/src/main/java/com/github/jenkinsx/quickstarts/vertx/rest/prometheus/VertxRestPrometheusVerticle.java
+++ b/src/main/java/com/github/jenkinsx/quickstarts/vertx/rest/prometheus/VertxRestPrometheusVerticle.java
@@ -26,6 +26,7 @@ public class VertxRestPrometheusVerticle extends AbstractVerticle {
 
         exposeHelloWorldEndpoint(router);
         exposeMetricsEndpoint(router);
+        exposeHealthEndpoint(router);
 
         vertx.createHttpServer().requestHandler(router::accept).listen(8080);
         super.start(startFuture);
@@ -43,6 +44,14 @@ public class VertxRestPrometheusVerticle extends AbstractVerticle {
     private void exposeMetricsEndpoint(Router router) {
         DefaultExports.initialize();
         router.route("/metrics").handler(new MetricsHandler(registry));
+    }
+
+    private void exposeHealthEndpoint(Router router) {
+        router.route("/actuator/health").handler(routingContext -> {
+            HttpServerResponse response = routingContext.response();
+            response.putHeader("content-type", "text/plain");
+            response.end("OK");
+        });
     }
 
     // IDE testing helper


### PR DESCRIPTION
See [this](https://github.com/jenkins-x/draft-packs/blob/787f6e7eb897a1d71c7b4544fbb82e770191ad96/packs/maven/charts/values.yaml#L24). Otherwise the pod just goes into a restart loop.